### PR TITLE
Added the option to redirect the Miniconda target link

### DIFF
--- a/docker/goseek-base/Dockerfile
+++ b/docker/goseek-base/Dockerfile
@@ -19,12 +19,12 @@ RUN apt-get update && \
     apt-get install -y git curl && \
     apt-get clean
 
-RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
-     chmod +x ~/miniconda.sh && \
-     ~/miniconda.sh -b -p /opt/conda && \
-     rm ~/miniconda.sh && \
-     /opt/conda/bin/conda clean -ya && \
-     /opt/conda/bin/conda create -y -n python37 python=3.7 numpy pip scipy pyyaml pillow
+RUN curl -L -o ~/miniconda.sh -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+    chmod +x ~/miniconda.sh && \
+    ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh && \
+    /opt/conda/bin/conda clean -ya && \
+    /opt/conda/bin/conda create -y -n python37 python=3.7 numpy pip scipy pyyaml pillow
 
 RUN /opt/conda/bin/conda update -y -n base -c defaults conda
 


### PR DESCRIPTION
When testing the docker installation on a new machine, the following error was found:

![error](https://user-images.githubusercontent.com/8823015/79067524-d4d7e700-7cb7-11ea-945e-0352a211959c.png)

After debugging, I found out the ~/miniconda.sh was empty and the curl needed to be able to follow the redirect of the target link. So I added that option and the rest worked as intended.